### PR TITLE
Add end time display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "@storybook/addon-links": "^6.1.21",
         "@storybook/node-logger": "^6.1.21",
         "@storybook/preset-create-react-app": "^3.1.6",
-        "@storybook/react": "^6.1.21"
+        "@storybook/react": "^6.1.21",
+        "prettier": "2.0.5"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@storybook/addon-links": "^6.1.21",
     "@storybook/node-logger": "^6.1.21",
     "@storybook/preset-create-react-app": "^3.1.6",
-    "@storybook/react": "^6.1.21"
+    "@storybook/react": "^6.1.21",
+    "prettier": "2.0.5"
   }
 }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -6,16 +6,16 @@ import { ReactComponent as StopButton } from '../../assets/stop-icon.svg'
 import { useState, useEffect } from 'react'
 
 function App() {
-  const LENGTHTWENTYFIVE = { minutes: 25, seconds: 0 }
-  const LENGTHFIFTY = { minutes: 50, seconds: 0 }
+  const DURATIONTWENTYFIVE = { minutes: 25, seconds: 0 }
+  const DURATIONFIFTY = { minutes: 50, seconds: 0 }
 
-  const [lengthLong, setLengthLong] = useState(false)
+  const [durationLong, setDurationLong] = useState(false)
   const [isActive, setIsActive] = useState(false)
   const [[endHours, endMinutes], setEndTime] = useState([])
   const [timerExpired, setTimerExpired] = useState(false)
   const [[minutes, seconds], setCounter] = useState([
-    LENGTHTWENTYFIVE.minutes,
-    LENGTHTWENTYFIVE.seconds,
+    DURATIONTWENTYFIVE.minutes,
+    DURATIONTWENTYFIVE.seconds,
   ])
 
   function timer() {
@@ -40,65 +40,61 @@ function App() {
     const currentDateObj = new Date()
     const endDateObj = new Date()
 
-    lengthLong
+    durationLong
       ? endDateObj.setTime(
-          currentDateObj.getTime() + LENGTHFIFTY.minutes * 60 * 1000
+          currentDateObj.getTime() + DURATIONFIFTY.minutes * 60 * 1000
         )
       : endDateObj.setTime(
-          currentDateObj.getTime() + LENGTHTWENTYFIVE.minutes * 60 * 1000
+          currentDateObj.getTime() + DURATIONTWENTYFIVE.minutes * 60 * 1000
         )
     setEndTime([endDateObj.getHours(), endDateObj.getMinutes()])
   }
 
   function handleStop() {
-    lengthLong
+    durationLong
       ? setCounter([
-          parseInt(LENGTHFIFTY.minutes),
-          parseInt(LENGTHFIFTY.seconds),
+          parseInt(DURATIONFIFTY.minutes),
+          parseInt(DURATIONFIFTY.seconds),
         ])
       : setCounter([
-          parseInt(LENGTHTWENTYFIVE.minutes),
-          parseInt(LENGTHTWENTYFIVE.seconds),
+          parseInt(DURATIONTWENTYFIVE.minutes),
+          parseInt(DURATIONTWENTYFIVE.seconds),
         ])
     setTimerExpired(false)
     setIsActive(false)
   }
 
-  function handleLengthShort() {
-    setLengthLong(false)
-    setCounter([LENGTHTWENTYFIVE.minutes, LENGTHTWENTYFIVE.seconds])
+  function handleDurationShort() {
+    setDurationLong(false)
+    setCounter([DURATIONTWENTYFIVE.minutes, DURATIONTWENTYFIVE.seconds])
   }
 
-  function handleLengthLong() {
-    setLengthLong(true)
-    setCounter([LENGTHFIFTY.minutes, LENGTHFIFTY.seconds])
+  function handleDurationLong() {
+    setDurationLong(true)
+    setCounter([DURATIONFIFTY.minutes, DURATIONFIFTY.seconds])
   }
 
   return (
     <AppGrid>
       <CountdownGrid>
         <Countdown minutes={minutes} seconds={seconds} />
-        {isActive ? (
-          <EndTime endHours={endHours} endMinutes={endMinutes} />
-        ) : (
-          ''
-        )}
+        {isActive && <EndTime endHours={endHours} endMinutes={endMinutes} />}
       </CountdownGrid>
       <ConfigurationGrid>
-        <CountdownLength
-          onClick={handleLengthShort}
+        <CountdownDuration
+          onClick={handleDurationShort}
           disabled={isActive}
-          selected={!lengthLong}
+          selected={!durationLong}
         >
           25:00
-        </CountdownLength>
-        <CountdownLength
-          onClick={handleLengthLong}
+        </CountdownDuration>
+        <CountdownDuration
+          onClick={handleDurationLong}
           disabled={isActive}
-          selected={lengthLong}
+          selected={durationLong}
         >
           50:00
-        </CountdownLength>
+        </CountdownDuration>
       </ConfigurationGrid>
       <StartStopGrid>
         {!isActive ? (
@@ -147,7 +143,7 @@ const StartStopGrid = styled.section`
   padding: 10px;
 `
 
-const CountdownLength = styled.button`
+const CountdownDuration = styled.button`
   color: ${props => (props.selected ? '#52DFD1' : '#585858')};
   border: none;
   background-color: transparent;

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components/macro'
 import Countdown from '../Countdown/Countdown'
+import EndTime from '../EndTime/EndTime'
 import { ReactComponent as PlayButton } from '../../assets/play-icon.svg'
 import { ReactComponent as StopButton } from '../../assets/stop-icon.svg'
 import { useState, useEffect } from 'react'
@@ -11,6 +12,7 @@ function App() {
   const [lengthLong, setLengthLong] = useState(false)
   const [isActive, setIsActive] = useState(false)
   const [timerExpired, setTimerExpired] = useState(false)
+  const [[endHours, endMinutes], setEndTime] = useState([])
   const [[minutes, seconds], setCounter] = useState([
     LENGTHTWENTYFIVE.minutes,
     LENGTHTWENTYFIVE.seconds,
@@ -33,6 +35,19 @@ function App() {
     }
   })
 
+  function handleStart() {
+    setIsActive(true)
+    const currentDateObj = new Date()
+    const endDateObj = new Date()
+
+    lengthLong
+      ? endDateObj.setTime(currentDateObj.getTime() + 50 * 60 * 1000)
+      : endDateObj.setTime(currentDateObj.getTime() + 25 * 60 * 1000)
+    setEndTime([endDateObj.getHours(), endDateObj.getMinutes()])
+    console.log(endDateObj)
+    console.log([endDateObj.getHours(), endDateObj.getMinutes()])
+  }
+
   function handleStop() {
     lengthLong
       ? setCounter([
@@ -47,10 +62,6 @@ function App() {
     setIsActive(false)
   }
 
-  function handleStart() {
-    setIsActive(true)
-  }
-
   function handleLengthShort() {
     setLengthLong(false)
     setCounter([LENGTHTWENTYFIVE.minutes, LENGTHTWENTYFIVE.seconds])
@@ -63,58 +74,82 @@ function App() {
 
   return (
     <AppGrid>
-      <Countdown minutes={minutes} seconds={seconds} />
-      <LengthButtonGrid>
-        <TimerLength
+      <CountdownGrid>
+        <Countdown minutes={minutes} seconds={seconds} />
+        {isActive ? (
+          <EndTime endHours={endHours} endMinutes={endMinutes} />
+        ) : (
+          ''
+        )}
+      </CountdownGrid>
+      <ConfigurationGrid>
+        <CountdownLength
           onClick={handleLengthShort}
           disabled={isActive}
           selected={!lengthLong}
         >
           25:00
-        </TimerLength>
-        <TimerLength
+        </CountdownLength>
+        <CountdownLength
           onClick={handleLengthLong}
           disabled={isActive}
           selected={lengthLong}
         >
           50:00
-        </TimerLength>
-      </LengthButtonGrid>
-      {!isActive ? (
-        <PlayButton role="button" onClick={handleStart} />
-      ) : (
-        <StopButton role="button" onClick={handleStop} />
-      )}
+        </CountdownLength>
+      </ConfigurationGrid>
+      <StartStopGrid>
+        {!isActive ? (
+          <PlayButton role="button" onClick={handleStart} />
+        ) : (
+          <StopButton role="button" onClick={handleStop} />
+        )}
+      </StartStopGrid>
     </AppGrid>
   )
 }
 
 export default App
 
-const AppGrid = styled.div`
+const AppGrid = styled.main`
   display: grid;
   position: fixed;
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
-  place-content: center;
-  place-items: center;
-  gap: 40px;
+  grid-template-rows: 1fr 1fr 100px;
 `
 
-const LengthButtonGrid = styled.div`
+const CountdownGrid = styled.section`
   display: grid;
-  grid-template-columns: 1fr 1fr;
   gap: 10px;
+  grid-template-rows: 1fr 30px;
+  align-items: end;
+  justify-items: center;
 `
 
-const TimerLength = styled.button`
+const ConfigurationGrid = styled.section`
+  display: grid;
+  grid-template-columns: auto auto;
+  align-content: end;
+  justify-content: center;
+  gap: 10px;
+  padding: 20px;
+`
+
+const StartStopGrid = styled.section`
+  display: grid;
+  align-content: start;
+  justify-content: center;
+  padding: 10px;
+`
+
+const CountdownLength = styled.button`
   color: ${props => (props.selected ? '#52DFD1' : '#585858')};
   border: none;
-  width: fit-content;
-  height: fit-content;
   background-color: transparent;
   font-size: 20px;
-  padding: 0;
+  width: fit-content;
+  height: fit-content;
 `

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -41,8 +41,12 @@ function App() {
     const endDateObj = new Date()
 
     lengthLong
-      ? endDateObj.setTime(currentDateObj.getTime() + 50 * 60 * 1000)
-      : endDateObj.setTime(currentDateObj.getTime() + 25 * 60 * 1000)
+      ? endDateObj.setTime(
+          currentDateObj.getTime() + LENGTHFIFTY.minutes * 60 * 1000
+        )
+      : endDateObj.setTime(
+          currentDateObj.getTime() + LENGTHTWENTYFIVE.minutes * 60 * 1000
+        )
     setEndTime([endDateObj.getHours(), endDateObj.getMinutes()])
   }
 

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -11,8 +11,8 @@ function App() {
 
   const [lengthLong, setLengthLong] = useState(false)
   const [isActive, setIsActive] = useState(false)
-  const [timerExpired, setTimerExpired] = useState(false)
   const [[endHours, endMinutes], setEndTime] = useState([])
+  const [timerExpired, setTimerExpired] = useState(false)
   const [[minutes, seconds], setCounter] = useState([
     LENGTHTWENTYFIVE.minutes,
     LENGTHTWENTYFIVE.seconds,
@@ -44,8 +44,6 @@ function App() {
       ? endDateObj.setTime(currentDateObj.getTime() + 50 * 60 * 1000)
       : endDateObj.setTime(currentDateObj.getTime() + 25 * 60 * 1000)
     setEndTime([endDateObj.getHours(), endDateObj.getMinutes()])
-    console.log(endDateObj)
-    console.log([endDateObj.getHours(), endDateObj.getMinutes()])
   }
 
   function handleStop() {

--- a/src/components/Countdown/Countdown.jsx
+++ b/src/components/Countdown/Countdown.jsx
@@ -11,7 +11,6 @@ export default function Countdown({ minutes, seconds }) {
   )
 }
 
-const CountdownWrapper = styled.div`
+const CountdownWrapper = styled.span`
   font-size: 50px;
-  padding: 100px;
 `

--- a/src/components/EndTime/EndTime.jsx
+++ b/src/components/EndTime/EndTime.jsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components/macro'
+
+export default function EndTime({ endHours, endMinutes }) {
+  const displayEndHours = endHours.toString().padStart(2, '0')
+  const displayEndMinutes = endMinutes.toString().padStart(2, '0')
+
+  return (
+    <TimeWrapper>
+      {displayEndHours}:{displayEndMinutes}
+    </TimeWrapper>
+  )
+}
+
+const TimeWrapper = styled.span`
+  font-size: 20px;
+  color: #c2c2c2;
+`

--- a/src/components/EndTime/EndTime.spec.js
+++ b/src/components/EndTime/EndTime.spec.js
@@ -1,0 +1,9 @@
+import { screen, render } from '@testing-library/react'
+import EndTime from './EndTime'
+
+describe('EndTime', () => {
+  it('renders the prospective time for the end of the countdown', () => {
+    render(<EndTime endHours={8} endMinutes={10} />)
+    expect(screen.getByText('08:10')).toBeInTheDocument()
+  })
+})

--- a/src/components/EndTime/EndTime.stories.js
+++ b/src/components/EndTime/EndTime.stories.js
@@ -1,0 +1,8 @@
+import EndTime from './EndTime'
+
+export default {
+  title: 'EndTime',
+  components: EndTime,
+}
+
+export const Time = () => <EndTime endHours={8} endMinutes={10} />


### PR DESCRIPTION
## Value Statement
As a **user**
I need an **indication of the time at the end of the countdown**
to be able to **enhance my time management while being fully concentrate on the tasks ahead and thus, be more productive.** 

## Acceptance Criteria
- Time is visible while countdown is active (hidden while countdown is stopped or after its finished)
